### PR TITLE
Replace grid with Swiper carousel

### DIFF
--- a/src/components/Home/GallerySection.js
+++ b/src/components/Home/GallerySection.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { galleryData } from "../../data/data";
-import PhotoAlbum from "react-photo-album";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
 import Lightbox from "yet-another-react-lightbox";
 import "yet-another-react-lightbox/styles.css";
 import { motion } from "framer-motion";
@@ -15,9 +16,8 @@ const slides = galleryData.images.map(({ original, width, height }) => ({
 
 const GallerySection = () => {
   const [index, setIndex] = useState(-1);
-  const displayPhoto = (event) => {
-    console.log(event.index);
-    setIndex(event.index);
+  const displayPhoto = (i) => {
+    setIndex(i);
   };
 
   const { title, btnText, btnIcon, images } = galleryData;
@@ -33,7 +33,7 @@ const GallerySection = () => {
   return (
     <section
       ref={galleryRef}
-      className="bg-[#F9F9F9] section relative mt-[40px] lg:mt-0 px-4 md:px-10"
+      className="bg-[#F9F9F9] min-h-screen section relative mt-[40px] lg:mt-0 px-4 md:px-10"
     >
       <div className="container mx-auto">
         <motion.h2
@@ -54,7 +54,24 @@ const GallerySection = () => {
         viewport={{ once: false, amount: 0.2 }}
         className="mb-8 lg:mb-20"
       >
-        <PhotoAlbum layout="rows" photos={images} onClick={displayPhoto} />
+        <Swiper
+          spaceBetween={20}
+          breakpoints={{
+            640: { slidesPerView: 2 },
+            1024: { slidesPerView: 3 },
+          }}
+        >
+          {images.map((img, i) => (
+            <SwiperSlide key={i}>
+              <img
+                src={img.src}
+                alt="gallery"
+                className="w-full h-full object-cover cursor-pointer"
+                onClick={() => displayPhoto(i)}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
         <Lightbox
           slides={slides}
           styles={{ container: { backgroundColor: "rgba(0,0,0,.9)" } }}


### PR DESCRIPTION
## Summary
- switch gallery to `Swiper` slides
- enlarge gallery section height
- trigger lightbox on slide click and remove debug log

## Testing
- `npm install` *(to install dependencies)*
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f73cfa748329b1b2291519c12b5c