### PR TITLE
Enhance video gallery navigation

### DIFF
--- a/src/components/Home/VideoGallery.js
+++ b/src/components/Home/VideoGallery.js
@@ -3,10 +3,11 @@ import { videoData } from "../../data/data";
 import { motion } from "framer-motion";
 import { fadeIn } from "../../utils/varients";
 import { useLocation } from "react-router-dom";
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 
 const VideoGallery = () => {
   const galleryRef = useRef(null);
-  const [activeVideo, setActiveVideo] = useState(null);
+  const [activeIndex, setActiveIndex] = useState(null);
   const { pathname } = useLocation();
 
   useEffect(() => {
@@ -15,17 +16,46 @@ const VideoGallery = () => {
     }
   }, [pathname]);
 
+  const nextVideo = (e) => {
+    e.stopPropagation();
+    setActiveIndex((prev) =>
+      prev === videoData.videos.length - 1 ? 0 : prev + 1
+    );
+  };
+
+  const prevVideo = (e) => {
+    e.stopPropagation();
+    setActiveIndex((prev) =>
+      prev === 0 ? videoData.videos.length - 1 : prev - 1
+    );
+  };
+
+  const activeVideo =
+    activeIndex !== null ? videoData.videos[activeIndex].id : null;
+
   return (
     <>
-      {activeVideo && (
+      {activeIndex !== null && (
         <div
           className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
-          onClick={() => setActiveVideo(null)}
+          onClick={() => setActiveIndex(null)}
         >
           <div
-            className="w-full max-w-3xl"
+            className="relative w-full max-w-3xl"
             onClick={(e) => e.stopPropagation()}
           >
+            <button
+              className="absolute left-2 top-1/2 -translate-y-1/2 text-white text-3xl p-2"
+              onClick={prevVideo}
+            >
+              <FaChevronLeft />
+            </button>
+            <button
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-white text-3xl p-2"
+              onClick={nextVideo}
+            >
+              <FaChevronRight />
+            </button>
             <div className="relative pb-[56.25%] h-0">
               <iframe
                 className="absolute top-0 left-0 w-full h-full"
@@ -54,7 +84,7 @@ const VideoGallery = () => {
             <div
               key={index}
               className="flex-shrink-0 w-full sm:w-1/2 lg:w-1/3 cursor-pointer"
-              onClick={() => setActiveVideo(video.id)}
+              onClick={() => setActiveIndex(index)}
             >
               <div className="relative pb-[56.25%] h-0">
                 <iframe


### PR DESCRIPTION
## Summary
- add chevron icons for navigation
- track active video by index
- enable previous/next controls with wrapping

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866f72be1348329b45623dea32b13bd