### PR TITLE
Fix logo height and align header menu

### DIFF
--- a/src/components/TopBar/Header.js
+++ b/src/components/TopBar/Header.js
@@ -6,18 +6,17 @@ import NavMobile from "./NavMobile";
 import Socials from "./Social";
 import logo from './../../asset/topbar/logo.png';
 import styled from "styled-components";
-import tw from "twin.macro";
 // import icons
 
 
 const Logo = styled.div`
-  ${ tw`
-mt-4
-mb-14
-  `}
-  width:200px;
-  height:160px;
-  `;
+  width: 200px;
+  height: 110px;
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`;
 export const Header = () => {
   const [isActive, setIsActive] = useState(false);
   const [navMobile, setNavMobile] = useState(false);


### PR DESCRIPTION
## Summary
- adjust styled Logo to match header height and drop extra margin

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f73fd12883298bcd65d24a9c0540