### PR TITLE
Improve home page layout

### DIFF
--- a/src/components/Home/About.js
+++ b/src/components/Home/About.js
@@ -10,9 +10,9 @@ import tw from "twin.macro";
 
 const AboutContainer = styled.div`
   ${tw`
-    mt-40
-    mb-40
-    h-full
+    min-h-screen
+    flex
+    items-center
     w-full
   `}
 `;

--- a/src/components/Home/About1.js
+++ b/src/components/Home/About1.js
@@ -10,9 +10,9 @@ import tw from "twin.macro";
 
 const AboutContainer = styled.div`
   ${tw`
-    mt-40
-    mb-40
-    h-full
+    min-h-screen
+    flex
+    items-center
     w-full
   `}
 `;

--- a/src/components/Home/Contact.js
+++ b/src/components/Home/Contact.js
@@ -14,7 +14,7 @@ const Contact = () => {
   }, [pathname]);
 
   return (
-    <section ref={contactRef} className="section">
+    <section ref={contactRef} className="section min-h-screen flex items-center">
       <div className="container mx-auto">
         <div className="flex flex-col xl:flex-row gap-y-16">
           {/* Removed the entire block that renders the contact info */}

--- a/src/components/Home/HomeSectionsSlider.js
+++ b/src/components/Home/HomeSectionsSlider.js
@@ -9,17 +9,17 @@ import Interview1 from "./Interview1";
 
 const HomeSectionsSlider = () => {
   return (
-    <Swiper>
-      <SwiperSlide>
+    <Swiper className="h-screen">
+      <SwiperSlide className="h-full">
         <About />
       </SwiperSlide>
-      <SwiperSlide>
+      <SwiperSlide className="h-full">
         <Interview />
       </SwiperSlide>
-      <SwiperSlide>
+      <SwiperSlide className="h-full">
         <About1 />
       </SwiperSlide>
-      <SwiperSlide>
+      <SwiperSlide className="h-full">
         <Interview1 />
       </SwiperSlide>
     </Swiper>

--- a/src/components/Home/Interview.js
+++ b/src/components/Home/Interview.js
@@ -23,7 +23,7 @@ const Interview = () => {
         initial="hidden"
         whileInView={'show'}
         viewport={{ once: false, amount: 0.1 }}
-        className="section bg-dark"
+        className="section bg-dark min-h-screen flex items-center"
       >
         <div className="container mx-auto h-full">
           <div className="flex flex-col lg:flex-row justify-center h-full">

--- a/src/components/Home/Interview1.js
+++ b/src/components/Home/Interview1.js
@@ -23,7 +23,7 @@ const Interview1 = () => {
         initial="hidden"
         whileInView={'show'}
         viewport={{ once: false, amount: 0.1 }}
-        className="section bg-dark h-full"
+        className="section bg-dark min-h-screen flex items-center"
       >
         <div className="container mx-auto h-full">
           <div className="flex flex-col lg:flex-row justify-center h-full">

--- a/src/components/Home/VideoGallery.js
+++ b/src/components/Home/VideoGallery.js
@@ -75,7 +75,7 @@ import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
          whileInView="show"
          viewport={{ once: false, amount: 0.2 }}
          ref={galleryRef}
-       className="section"
+       className="section min-h-screen flex items-center"
      >
        <div className="container mx-auto">
          <h2 className="h2 mb-8">{videoData.title}</h2>

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -1,22 +1,17 @@
 import React from "react";
 // import { Outlet } from "react-router-dom";
-import { Header } from "../TopBar/Header";
 import Contact from "./Contact";
 import Footer from "./Footer";
 import VideoGallery from "./VideoGallery";
 import LandingPage from "./LandingPage";
-import Skills from "./Skills";
-import Testimonial from "./Testimonial";
 import GallerySection from "./GallerySection";
 import HomeSectionsSlider from "./HomeSectionsSlider";
 const index = () => {
   return (
     <>
       <LandingPage />
-          <Header/>
 
       {/* <Outlet /> */}
-      <div/>
       <HomeSectionsSlider />
       <GallerySection/>
       <VideoGallery />

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -57,7 +57,7 @@ export const about1Data = {
   btnIcon: <IoMdArrowForward />,
 };
 export const galleryData = {
-  title: "",
+  title: "Gallery",
   btnText: "View all",
   btnIcon: <IoMdArrowForward />,
   images: [


### PR DESCRIPTION
## Summary
- add a title for the gallery section
- make each home page section fill the screen
- clean up Home index component

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68671f04601c8329a8ed08c204912cee